### PR TITLE
Remove lib from eslint ignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 dist/
-lib/
 node_modules/
 jest.config.js


### PR DESCRIPTION
Remove the lib directory from the eslint ignore. The TypeScript action
template used this as an output directory for tsc but I changed the
TypeScript compiler command to not emit.